### PR TITLE
Add query arg for delay parameter on lines

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+MTA_KEY=<<YOUR API KEY>>

--- a/app/models/display/line_direction.rb
+++ b/app/models/display/line_direction.rb
@@ -35,40 +35,26 @@ module Display
 
     def max_actual_headway
       @max_actual_headway if @max_actual_headway
-      times = trips.map { |t|
-        time = t.upcoming_line_directions[line_direction]
+      compute_actual_headways
+      @max_actual_headway
+    end
 
-        # Facilitate M train shuffle (where M train stops for Broadway-Brooklyn line are reverse of J/Z trains)
-        if !time && t.route_id == "M" && line_direction.line.name == "Broadway (Brooklyn)"
-          time = t.find_time(last_stop_reverse)
-        end
-        time
-      }
-      times << trips.first.timestamp if times.size == 1
-      @max_actual_headway = times.sort.each_cons(2).map { |a,b| (b - a) / 60 }.max
+    def median_actual_headway
+      @median_actual_headway if @median_actual_headway
+      compute_actual_headways
+      @median_actual_headway
     end
 
     def max_scheduled_headway
       @max_scheduled_headway if @max_scheduled_headway
-      return nil if stop_times[line_direction.last_stop].nil?
+      compute_scheduled_headways
+      @max_scheduled_headway
+    end
 
-      # Facilitate M train shuffle
-      if line_direction.line.name == "Broadway (Brooklyn)"
-        st = stop_times[line_direction.last_stop].select { |st| st.trip.route_internal_id != "M"}
-        st.concat(stop_times[last_stop_reverse].select { |st| st.trip.route_internal_id == "M"})
-      else
-        st = stop_times[line_direction.last_stop]
-      end
-
-      if line_direction.kind_of?(ExpressLineDirection)
-        st.reject! { |st|
-          stop_times[line_direction.local_line_direction.last_stop].any? { |local_st|
-            st.trip_internal_id == local_st.trip_internal_id
-          }
-        }
-      end
-      times = st.map(&:departure_time)
-      @max_scheduled_headway = treat_times(times).sort.each_cons(2).map { |a,b| (b - a) / 60 }.max
+    def median_scheduled_headway
+      @median_scheduled_headway if @median_scheduled_headway
+      compute_scheduled_headways
+      @median_scheduled_headway
     end
 
     def headway_discreprency
@@ -104,5 +90,63 @@ module Display
       end
       times
     end
+
+    def compute_actual_headways
+      times = trips.map { |t|
+        time = t.upcoming_line_directions[line_direction]
+
+        # Facilitate M train shuffle (where M train stops for Broadway-Brooklyn line are reverse of J/Z trains)
+        if !time && t.route_id == "M" && line_direction.line.name == "Broadway (Brooklyn)"
+          time = t.find_time(last_stop_reverse)
+        end
+        time
+      }
+      times << trips.first.timestamp if times.size == 1
+      headways = times.sort.each_cons(2).map { |a, b| (b - a) }
+      len = headways.size
+      if len == 0
+        @median_actual_headway = nil
+        @max_actual_headway = nil
+        return
+      end
+
+      @median_actual_headway = ((headways[(len - 1) / 2] + headways[len / 2]) / 2.0) / 60
+      @max_actual_headway = headways.max / 60
+    end
+
+    def compute_scheduled_headways
+      if stop_times[line_direction.last_stop].nil?
+        @median_scheduled_headway = nil
+        @max_scheduled_headway = nil
+        return nil
+      end
+
+      # Facilitate M train shuffle
+      if line_direction.line.name == "Broadway (Brooklyn)"
+        st = stop_times[line_direction.last_stop].select { |st| st.trip.route_internal_id != "M"}
+        st.concat(stop_times[last_stop_reverse].select { |st| st.trip.route_internal_id == "M"})
+      else
+        st = stop_times[line_direction.last_stop]
+      end
+
+      if line_direction.kind_of?(ExpressLineDirection)
+        st.reject! { |st|
+          stop_times[line_direction.local_line_direction.last_stop].any? { |local_st|
+            st.trip_internal_id == local_st.trip_internal_id
+          }
+        }
+      end
+      headways = treat_times(st.map(&:departure_time)).sort.each_cons(2).map { |a, b| (b - a) }
+      len = headways.size
+      if len == 0
+        @median_scheduled_headway = nil
+        @max_scheduled_headway = nil
+        return
+      end
+
+      @median_scheduled_headway = ((headways[(len - 1) / 2] + headways[len / 2]) / 60) / 2.0
+      @max_scheduled_headway = headways.max / 60
+    end
+
   end
 end

--- a/app/models/display/route_line_direction.rb
+++ b/app/models/display/route_line_direction.rb
@@ -23,28 +23,28 @@ module Display
 
     def max_actual_headway
       @max_actual_headway if @max_actual_headway
-      times = trips.map { |t|
-        t.upcoming_line_directions[line_direction]
-      }
-      times << trips.first.timestamp if times.size == 1
-      @max_actual_headway = times.sort.each_cons(2).map { |a,b| (b - a) / 60 }.max
+      compute_actual_headways
+      @max_actual_headway
+    end
+
+    def median_actual_headway
+      @median_actual_headway if @median_actual_headway
+      compute_actual_headways
+      @median_actual_headway
     end
 
     def max_scheduled_headway
       @max_scheduled_headway if @max_scheduled_headway
-      return nil if stop_times[line_direction.last_stop].nil?
-      st = stop_times[line_direction.last_stop].select { |st| st.trip.route_internal_id == route_id}
-      if line_direction.kind_of?(ExpressLineDirection)
-        st.reject! { |st|
-          stop_times[line_direction.local_line_direction.last_stop].any? { |local_st|
-            st.trip_internal_id == local_st.trip_internal_id
-          }
-        }
-      end
-      times = st.map(&:departure_time)
-      @max_scheduled_headway = treat_times(times).sort.each_cons(2).map { |a,b| (b - a) / 60 }.max
+      compute_scheduled_headways
+      @max_scheduled_headway
     end
 
+    def median_scheduled_headway
+      @median_scheduled_headway if @median_scheduled_headway
+      compute_scheduled_headways
+      @median_scheduled_headway
+    end
+    
     def headway_discreprency
       return nil if trips.empty?
       max_actual_headway - max_scheduled_headway if max_scheduled_headway
@@ -53,6 +53,50 @@ module Display
     private
 
     attr_accessor :trips, :stop_times, :line_direction, :route_id, :timestamp
+
+    def compute_actual_headways
+      times = trips.map { |t|
+        t.upcoming_line_directions[line_direction]
+      }
+      times << trips.first.timestamp if times.size == 1
+      headways = times.sort.each_cons(2).map { |a, b| (b - a) }
+      len = headways.size
+      if len == 0
+        @max_actual_headway = nil
+        @median_actual_headway = nil
+        return
+      end
+      @median_actual_headway = ((headways[(len - 1) / 2] + headways[len / 2]) / 2.0) / 60
+      @max_actual_headway = headways.max / 60
+    end
+
+    def compute_scheduled_headways
+      if stop_times[line_direction.last_stop].nil?
+        @median_scheduled_headway = nil
+        @max_scheduled_headway = nil
+        return nil
+      end
+
+      st = stop_times[line_direction.last_stop].select { |st| st.trip.route_internal_id == route_id}
+      if line_direction.kind_of?(ExpressLineDirection)
+        st.reject! { |st|
+          stop_times[line_direction.local_line_direction.last_stop].any? { |local_st|
+            st.trip_internal_id == local_st.trip_internal_id
+          }
+        }
+      end
+      headways = treat_times(st.map(&:departure_time)).sort.each_cons(2).map { |a, b| (b - a) }
+      len = headways.size
+      if len == 0
+        @max_scheduled_headway = nil
+        @median_scheduled_headway = nil
+        return nil
+      end
+
+      @max_scheduled_headway = headways.max / 60
+      @median_scheduled_headway = ((headways[(len - 1) / 2] + headways[len / 2]) / 2.0) / 60
+    end
+
 
     def treat_times(times)
       if (timestamp + 60.minutes).to_date == (timestamp.to_date + 1.day)

--- a/app/models/schedule_processor.rb
+++ b/app/models/schedule_processor.rb
@@ -160,6 +160,8 @@ class ScheduleProcessor
               type: ld.type,
               max_actual_headway: ld.max_actual_headway,
               max_scheduled_headway: ld.max_scheduled_headway,
+              median_actual_headway: ld.median_actual_headway,
+              median_scheduled_headway: ld.median_scheduled_headway,
               delay: ld.delay,
               routes: ld.routes.map { |route|
                 {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "babel-preset-react": "^6.24.1",
     "es-cookie": "^1.2.0",
     "prop-types": "^15.6.2",
+    "query-string": "^6.2.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-hammerjs": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4942,6 +4942,14 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.2.0.tgz#468edeb542b7e0538f9f9b1aeb26f034f19c86e1"
+  integrity sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -5830,6 +5838,11 @@ stream-shift@^1.0.0:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This is a small change that allows for a power user to specify the headway discrepancy they want to call "bad service" as a query argument. It moves (most of) the computation to the client side in the process.

Currently only does it for the lines because I wanted to see if @blahblahblah- wanted the general thrust done in some other manner.